### PR TITLE
Fixed filename error

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/BookUploadUtility.java
+++ b/portfolio/src/main/java/com/google/sps/data/BookUploadUtility.java
@@ -7,7 +7,7 @@ import com.google.sps.data.BookResponseParser;
 import com.google.sps.data.MergeBooks;
 
 // Given a book name, fetches it's info from Google Books Api and stores the response in Datastore.
-class BookUploadUtility {
+public class BookUploadUtility {
   // the BookServiceClient and the BookResponseParser are both static
   private final BookDao bookDao = new BookDaoDatastore();
 


### PR DESCRIPTION
I named the BookUploadUtility file wrong, it was utilty instead of utility (with an i). The error didn't show because when testing I was calling the file from the same package.